### PR TITLE
Return err bad conn when not leader

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2,6 +2,7 @@ package grpcsql
 
 import (
 	"database/sql/driver"
+	"io"
 
 	"github.com/CanonicalLtd/go-grpc-sql/internal/protocol"
 	"github.com/pkg/errors"
@@ -103,7 +104,9 @@ func (c *Conn) exec(request *protocol.Request) (*protocol.Response, error) {
 // If the given error is due to the gRPC endpoint being unavailable, return
 // ErrBadConn and mark the connection as doomed, otherwise return the original error.
 func (c *Conn) errorf(err error, format string, v ...interface{}) error {
-	if grpc.Code(err) == codes.Unavailable {
+	code := grpc.Code(err)
+	cause := errors.Cause(err)
+	if code == codes.Canceled || code == codes.Unavailable || cause == io.EOF {
 		c.grpcConnDoomed = true
 		return driver.ErrBadConn
 	}

--- a/conn.go
+++ b/conn.go
@@ -96,6 +96,12 @@ func (c *Conn) exec(request *protocol.Request) (*protocol.Response, error) {
 	}
 	switch response.Code {
 	case protocol.RequestCode_SQLITE_ERROR:
+		// FIXME: we compare the numeric code here to avoid importing
+		// go-sqlite3x.
+		err := response.SQLiteError()
+		if err.Code == 29 { // ErrNotLeader
+			return nil, driver.ErrBadConn
+		}
 		return nil, response.SQLiteError()
 	}
 	return response, nil

--- a/gateway.go
+++ b/gateway.go
@@ -54,6 +54,9 @@ func (s *Gateway) Conn(stream protocol.SQL_ConnServer) error {
 			case sqlite3.Error:
 				response = protocol.NewResponseSQLiteError(
 					err.Code, err.ExtendedCode, err.Error())
+			case sqlite3.ErrNo:
+				response = protocol.NewResponseSQLiteError(
+					err, 0, err.Error())
 			default:
 				return errors.Wrapf(err, "failed to handle %s request", request.Code)
 			}


### PR DESCRIPTION
This is a special case of sqlite/dqlite, where in case leadership is
lost we want to invalidate the connection, to give chance to the
builtin sql Go package connections pooling to try again against a
different node.
